### PR TITLE
fix(PhotoSharingSample): Update schema.graphql for TransformerV2 compatibility

### DIFF
--- a/Photo-Sharing-Sample/.gitignore
+++ b/Photo-Sharing-Sample/.gitignore
@@ -8,8 +8,8 @@ amplify/\#current-cloud-backend
 amplify/.config/local-*
 amplify/logs
 amplify/mock-data
+amplify/mock-api-resources
 amplify/backend/amplify-meta.json
-amplify/backend/awscloudformation
 amplify/backend/.temp
 build/
 dist/
@@ -22,4 +22,5 @@ amplify-build-config.json
 amplify-gradle-config.json
 amplifytools.xcconfig
 .secret-*
+**.sample
 #amplify-do-not-edit-end

--- a/Photo-Sharing-Sample/PhotoSharing/Views/SubViews/PostView.swift
+++ b/Photo-Sharing-Sample/PhotoSharing/Views/SubViews/PostView.swift
@@ -24,10 +24,10 @@ struct PostView: View {
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
-                UserProfileImageView(profileImageKey: viewModel.post.postedBy.profilePic)
+                UserProfileImageView(profileImageKey: viewModel.post.postedBy?.profilePic)
                     .asCircle(diameter: 36, lineWidth: 1)
                 VStack(alignment: .leading) {
-                    Text(viewModel.post.postedBy.username)
+                    Text(viewModel.post.postedBy?.username ?? "")
                         .font(.system(size: 20))
                         .bold()
                     CreatedAtSinceNowView(createdAt: viewModel.post.createdAt)

--- a/Photo-Sharing-Sample/PhotoSharing/Views/SubViews/UserProfileImageView.swift
+++ b/Photo-Sharing-Sample/PhotoSharing/Views/SubViews/UserProfileImageView.swift
@@ -12,13 +12,16 @@ struct UserProfileImageView: View {
 
     @StateObject private var viewModel: ViewModel
 
-    init(profileImageKey: String) {
-        _viewModel = StateObject(wrappedValue: ViewModel(profileImageKey: profileImageKey))
+    private static let emptyUserPicKey = "emptyUserPic"
+
+    init(profileImageKey: String?) {
+        _viewModel = StateObject(wrappedValue: ViewModel(profileImageKey: profileImageKey ??
+                                                         UserProfileImageView.emptyUserPicKey))
     }
 
     var body: some View {
         VStack {
-            if viewModel.profileImageKey == "emptyUserPic" {
+            if viewModel.profileImageKey == UserProfileImageView.emptyUserPicKey {
                 Image(systemName: "person.crop.circle")
                     .resizable()
                     .scaledToFill()

--- a/Photo-Sharing-Sample/PhotoSharingSample.xcodeproj/project.pbxproj
+++ b/Photo-Sharing-Sample/PhotoSharingSample.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			repositoryURL = "https://github.com/aws-amplify/amplify-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.12.0;
+				minimumVersion = 1.29.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Photo-Sharing-Sample/README.md
+++ b/Photo-Sharing-Sample/README.md
@@ -51,7 +51,18 @@ Before proceeding, please make sure you have followed the [instructions](https:/
 You need to have the following prerequisites to run this project:
 
 * [Xcode 12 or later](https://apps.apple.com/us/app/xcode/id497799835?mt=12)
-* [Amplify CLI latest version](https://docs.amplify.aws/cli)
+* [Amplify CLI](https://docs.amplify.aws/cli)
+
+The current tested version of Amplify CLI that is compatible with this app is 10.7.0. To check your Amplify CLI installed version, run:
+```
+> amplify --v
+10.7.0
+```
+
+To install a specific version of Amplify CLI:
+```
+npm i -g @aws-amplify/cli@10.7.0
+```
 
 Once you have the prerequisites installed, go ahead and clone the repository: 
 

--- a/Photo-Sharing-Sample/schema.graphql
+++ b/Photo-Sharing-Sample/schema.graphql
@@ -1,18 +1,18 @@
 type Post
     @model
-    @auth(rules: [{ allow: owner, operations: [create, delete] }]) {
+    @auth(rules: [{ allow: owner }]) {
     id: ID!
     postBody: String!
     pictureKey: String!
     createdAt: AWSDateTime!
-    postedBy: User! @belongsTo
+    postedBy: User @belongsTo
 }
 
 type User
     @model
-    @auth(rules: [{ allow: owner, operations: [create, delete] }]) {
+    @auth(rules: [{ allow: owner }]) {
     id: ID!
     username: String!
     profilePic: String!
-    posts: [Post] @hasMany(fields: ["id"])
+    posts: [Post] @hasMany
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-swift/issues/2742

*Description of changes:*
See https://github.com/aws-amplify/amplify-swift/issues/2742#issuecomment-1419250765

- removed explicit use of `operations` on the auth rule to allow owners to read and update the data.
- removed incomplete usage of `indexName` and `fields`? by removing `fields` from `@hasMany`. 
- removed required association of User on the Post model. This allows deferred association of models, such that I can create a post without a user, and then later assign which user that post belongs to. This change isn't required to fix the issue, but decided to add this in to make the data validation more relaxed.

We should run/re-run `amplify codegen models` and use the sample app and make sure things are working as expected before merging this PR in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
